### PR TITLE
Added support for custom filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,13 @@ How to use
 How to add custom filters
 ---------------------------
 
-Filters are small files stored in a filters directory. The filename has to be the name of the filter + '.js'.
+From the nunjucks documentation at http://jlongster.github.io/nunjucks/templating.html#filters:
+
+>Filters are essentially functions that can be applied to variables. They are called with a pipe operator (|) and can take arguments.
+
+For more information on how to write customer Filters, take a look at the API documentation page at: http://jlongster.github.io/nunjucks/api#custom-filters
+
+To use customer filters with wintersmith, put the filter in its own file stored in a filters directory. The filename has to be the name of the filter + '.js'.
 
 so if your filter is in './filters/myfirstfilter.js' add a  nunjucks section like this to your config.json:
 
@@ -25,3 +31,5 @@ so if your filter is in './filters/myfirstfilter.js' add a  nunjucks section lik
     "filters": ["myfirstfilter"]
 }
 ```
+
+It will be available in your templates at 'myfirstfilter'

--- a/index.js
+++ b/index.js
@@ -14,15 +14,13 @@ module.exports = function(env, callback) {
     }
   };
 
-  loadFilters = function(nenv) {
-    if(env.config.nunjucks) {
-      if(env.config.nunjucks.filterdir) {
-        env.config.nunjucks.filters.map( function (name) {
-          file = path.join(env.config.nunjucks.filterdir, name + ".js");
-          filter = env.loadModule(env.resolvePath(file), true);
-          nenv.addFilter(name, filter);
-        });
-      }
+  var loadFilters = function(nenv) {
+    if(env.config.nunjucks && env.config.nunjucks.filterdir) {
+      env.config.nunjucks.filters.map( function (name) {
+        file = path.join(env.config.nunjucks.filterdir, name + ".js");
+        filter = env.loadModule(env.resolvePath(file), true);
+        nenv.addFilter(name, filter);
+      });
     }
   };
 


### PR DESCRIPTION
I have added the ability to add customer filters.
It looks in a directory specified in the config.json "nunjucks" section. It goes over a list of filters you specified in the same config file and tries to find them in the filters directory.
