### PR TITLE
Upgrade to nunjucks 1.1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   ],
   "license": "BSD",
   "dependencies": {
-    "nunjucks": "~1.0.0"
+    "nunjucks": "^1.1.0"
   }
 }


### PR DESCRIPTION
There were a lot of improvements made and new tags created.  In particular I am interested in the `call` tag, which cannot be used with earlier versions before 1.1.0.
