### PR TITLE
Only use file watching option in preview mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ var path = require("path");
 module.exports = function(env, callback) {
 
   // Load the new nunjucks environment.
-  var loader = new nunjucks.FileSystemLoader(env.templatesPath, {watch: true});
+  var loaderOpts = {
+    watch: (env.mode == 'preview')
+  };
+  var loader = new nunjucks.FileSystemLoader(env.templatesPath, loaderOpts);
   var nenv = new nunjucks.Environment(loader);
 
   // Load the filters


### PR DESCRIPTION
This fixes a bug where wintersmith would not exit after building when the nunjucks plugin was loaded