### PR TITLE
Load filters from installed modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ so if your filter is in './filters/myfirstfilter.js' add a  nunjucks section lik
 It will be available in your templates at 'myfirstfilter'
 
 
-Filters that are already packaged in modules (like for example [nunjucks-date](https://www.npmjs.com/package/nunjucks-date)) can be loaded by specifying them like this in your config.json:
+Filters that are already packaged in modules (like for example [nunjucks-date](https://www.npmjs.com/package/nunjucks-date)) can be loaded by specifying them like this in your config.json, if they export an [install-method](https://github.com/techmsi/nunjucks-date/blob/0b1996f643abadddb3fd68ff565c733742617438/index.js#L40):
 
 ```javascript
 "nunjucks": {

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ so if your filter is in './filters/myfirstfilter.js' add a  nunjucks section lik
 It will be available in your templates at 'myfirstfilter'
 
 
+Filters that are already packaged in modules (like for example [nunjucks-date](https://www.npmjs.com/package/nunjucks-date)) can be loaded by specifying them like this in your config.json:
+
+```javascript
+"nunjucks": {
+    "filtermodules": "nunjucks-date"
+}
+```
+
+this specific filter would then be available as `date` in your templates.
+
 Autoescaping
 ------------
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,12 @@ module.exports = function(env, callback) {
       nenv.addFilter(name, filter);
     });
   }
+  if(env.config.nunjucks && env.config.nunjucks.filtermodules) {
+    env.config.nunjucks.filtermodules.map( function (name) {
+      var filter = require(name);
+      filter.install(nenv);
+    });
+  }
 
   // Configure nunjucks environment.
   if (env.config.nunjucks && env.config.nunjucks.autoescape != null) {


### PR DESCRIPTION
It's currently impossible to load nunjucks-filters from modules such as [nunjucks-date](https://www.npmjs.com/package/nunjucks-date). This PR adds a config-option that allows to specify such modules to be loaded:
```javascript
"nunjucks": {
    "filtermodules": "nunjucks-date"
}
```
