### PR TITLE
Update to nunjucks 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,6 @@ module.exports = function(env, callback) {
     callback(null, new NunjucksTemplate(nenv.getTemplate(filepath.relative)));
   };
 
-  env.registerTemplatePlugin("**/*.*(html|nunjucks)", NunjucksTemplate);
+  env.registerTemplatePlugin("**/*.*(html|nunjucks|njk)", NunjucksTemplate);
   callback();
 };

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ module.exports = function(env, callback) {
   // Configure nunjucks environment.
   if (env.config.nunjucks && env.config.nunjucks.autoescape != null) {
     nenv.opts.autoescape = env.config.nunjucks.autoescape;
+  } else {
+    nenv.opts.autoescape = false;
   }
 
   var NunjucksTemplate = function(template) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   ],
   "license": "BSD-2-Clause",
   "dependencies": {
-    "nunjucks": "^2.1.0"
+    "nunjucks": "^3.0.1"
   }
 }


### PR DESCRIPTION
This updates nunjucks to version 3 and adds support for the new preferred file extension `.njk`

I've also changed the auto escaping option to default to false again, we discussed this in #21 but I've realised since then that it does not make much sense to auto escape in a static site. There's no user input to safeguard against and I just end up turning it off for every project.